### PR TITLE
wraps Callback object when assigning to container

### DIFF
--- a/cmdtools/ext/command.py
+++ b/cmdtools/ext/command.py
@@ -111,13 +111,16 @@ class Group(Container):
             aliases = []
 
         def decorator(obj):
+            nonlocal name
+
             if inspect.isclass(obj) and Command in inspect.getmro(obj):
                 self.commands.append(obj())
             else:
-                if isinstance(obj, Callback):
-                    name = obj.func.__name__
-                elif isinstance(obj, Callable):
-                    name = obj.__name__
+                if not name:
+                    if isinstance(obj, Callback):
+                        name = obj.func.__name__
+                    elif isinstance(obj, Callable):
+                        name = obj.__name__
 
                 wrapper = GroupWrapper(name, aliases)
                 if isinstance(obj, Callback):

--- a/cmdtools/ext/command.py
+++ b/cmdtools/ext/command.py
@@ -114,8 +114,16 @@ class Group(Container):
             if inspect.isclass(obj) and Command in inspect.getmro(obj):
                 self.commands.append(obj())
             else:
-                wrapper = GroupWrapper(name or obj.__name__, aliases)
-                wrapper._callback = Callback(obj)
+                if isinstance(obj, Callback):
+                    name = obj.func.__name__
+                elif isinstance(obj, Callable):
+                    name = obj.__name__
+
+                wrapper = GroupWrapper(name, aliases)
+                if isinstance(obj, Callback):
+                    wrapper._callback = obj
+                else:
+                    wrapper._callback = Callback(obj)
                 self.commands.append(wrapper)
 
                 return wrapper


### PR DESCRIPTION
wraps `Callback` object to `GroupWrapper` when assigning command to `Group` or `Container`