### PR TITLE
restore old copy of `options`

### DIFF
--- a/cmdtools/__init__.py
+++ b/cmdtools/__init__.py
@@ -2,4 +2,4 @@ from cmdtools import callback
 from cmdtools.base import *
 from cmdtools.errors import *
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/cmdtools/base.py
+++ b/cmdtools/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any, Dict, List, Optional, Union
 
 from cmdtools import utils
@@ -146,6 +147,7 @@ class Executor:
             if error callback is not set.
         """
         result = None
+        old_options = copy.deepcopy(self.callback.options.options)
 
         try:
             context = self.callback.make_context(self.command, self.attrs)
@@ -159,6 +161,7 @@ class Executor:
             else:
                 raise exception
 
+        self.callback.options.options = old_options
         return result
 
     async def exec_coro(self) -> Optional[Any]:
@@ -176,6 +179,7 @@ class Executor:
             if error callback is not set.
         """
         result = None
+        old_options = copy.deepcopy(self.callback.options.options)
 
         try:
             context = self.callback.make_context(self.command, self.attrs)
@@ -189,6 +193,7 @@ class Executor:
             else:
                 raise exception
 
+        self.callback.options.options = old_options
         return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cmdtools-py"
-version = "3.0.0"
+version = "3.0.1"
 description = "command text parser and command processor"
 authors = ["HugeBrain16 <joshtuck373@gmail.com>"]
 maintainers = ["HugeBrain16 <joshtuck373@gmail.com>"]

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -9,6 +9,11 @@ def sumcmd(ctx: cmdtools.callback.Context):
     return sum(args2int)
 
 
+@cmdtools.callback.add_option("num", default=1, type=int)
+def test(ctx: cmdtools.callback.Context):
+    return ctx.options.num
+
+
 class TestExec(unittest.TestCase):
     def test_process(self):
         cmd = cmdtools.Cmd("/sum 10 10 10")
@@ -16,3 +21,12 @@ class TestExec(unittest.TestCase):
         res = executor.exec()
 
         self.assertEqual(res, 30)
+
+    def test_options(self):
+        cmd1 = cmdtools.Cmd("/test 2")
+        cmd2 = cmdtools.Cmd("/test")
+        exc1 = cmdtools.Executor(cmd1, test)
+        exc2 = cmdtools.Executor(cmd2, test)
+
+        self.assertEqual(exc1.exec(), 2)
+        self.assertEqual(exc2.exec(), 1)


### PR DESCRIPTION
Set callback options to the old copy after the command has finished executing.